### PR TITLE
Issue27 handle cancel buttons

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/app/src/androidTest/java/com/ad340/whatdo/MainActivityTest.java
+++ b/app/src/androidTest/java/com/ad340/whatdo/MainActivityTest.java
@@ -11,10 +11,13 @@ import androidx.test.espresso.Espresso;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.google.android.material.appbar.MaterialToolbar;
 
 import org.hamcrest.Matchers;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -236,8 +239,8 @@ public class MainActivityTest {
          int month = 5;
          int dayOfMonth = 28;
 
-         Thread.sleep(250);
          onView(withId(R.id.fab)).perform(click());
+         Thread.sleep(500);
          onView(withId(R.id.create_todo_dialog))
                  .check(matches(isDisplayed()));
 
@@ -245,18 +248,22 @@ public class MainActivityTest {
                  .perform(typeText("New Task"), closeSoftKeyboard());
 
          onView(withId(R.id.create_todo_time_btn)).perform(click());
+         Thread.sleep(500);
          onView(withClassName(Matchers.equalTo(
                  TimePicker.class.getName()))).perform(setTime(hourOfDay, minute));
          onView(withId(android.R.id.button1)).perform(click());
 
+         Thread.sleep(500);
          onView(withId(R.id.create_todo_time_text))
                  .check(matches(withText("4:30 PM")));
 
+         Thread.sleep(500);
          onView(withId(R.id.create_todo_date_btn)).perform(click());
          onView(withClassName(Matchers.equalTo(
                  DatePicker.class.getName()))).perform(setDate(year, month, dayOfMonth));
          onView(withId(android.R.id.button1)).perform(click());
 
+         Thread.sleep(500);
          onView(withId(R.id.create_todo_date_text))
                  .check(matches(withText("Thursday, May 28, 2020")));
 
@@ -267,15 +274,15 @@ public class MainActivityTest {
                  .check(matches(isDisplayed()));
 
          onView(withRecyclerView(R.id.todo_list_recycler_view)
-                 .atPositionOnView(3, R.id.name_text))
+                 .atPositionOnView(2, R.id.name_text))
                  .check(matches(withText("New Task")));
 
          onView(withRecyclerView(R.id.todo_list_recycler_view)
-                 .atPositionOnView(3, R.id.time_text))
+                 .atPositionOnView(2, R.id.time_text))
                  .check(matches(withText("4:30 PM")));
 
          onView(withRecyclerView(R.id.todo_list_recycler_view)
-                 .atPositionOnView(3, R.id.date_text))
+                 .atPositionOnView(2, R.id.date_text))
                  .check(matches(withText("Thursday, May 28, 2020")));
 
      }
@@ -288,54 +295,54 @@ public class MainActivityTest {
     public void tasksExpandAndCollapse() {
         // Date and buttons are invisible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_text))
+                .atPositionOnView(0, R.id.date_text))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.notes_btn))
+                .atPositionOnView(0, R.id.notes_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.time_btn))
+                .atPositionOnView(0, R.id.time_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_btn))
+                .atPositionOnView(0, R.id.date_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.reschedule_btn))
+                .atPositionOnView(0, R.id.reschedule_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
-        // Expand fifth task
+        // Expand first task
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.name_text))
+                .atPositionOnView(0, R.id.name_text))
                 .perform(click());
 
         // Date and buttons are visible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_text))
+                .atPositionOnView(0, R.id.date_text))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.reschedule_btn))
+                .atPositionOnView(0, R.id.reschedule_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.notes_btn))
+                .atPositionOnView(0, R.id.notes_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.time_btn))
+                .atPositionOnView(0, R.id.time_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_btn))
+                .atPositionOnView(0, R.id.date_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
-        // Collapse fifth task
+        // Collapse first task
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.name_text))
+                .atPositionOnView(0, R.id.name_text))
                 .perform(click());
 
         // Date and buttons are invisible
@@ -344,19 +351,19 @@ public class MainActivityTest {
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.reschedule_btn))
+                .atPositionOnView(0, R.id.reschedule_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.notes_btn))
+                .atPositionOnView(0, R.id.notes_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.time_btn))
+                .atPositionOnView(0, R.id.time_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_btn))
+                .atPositionOnView(0, R.id.date_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
     }
 
@@ -365,7 +372,7 @@ public class MainActivityTest {
         Tests whether tasks can be expanded from the time TextView or not
      */
     @Test
-    public void tasksExpandAndCollapse2() {
+    public void tasksExpandAndCollapse2() throws InterruptedException {
         // Date and buttons are invisible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
                 .atPositionOnView(4, R.id.date_text))
@@ -417,6 +424,8 @@ public class MainActivityTest {
         onView(withRecyclerView(R.id.todo_list_recycler_view)
                 .atPositionOnView(4, R.id.time_text))
                 .perform(click());
+
+        Thread.sleep(500);
 
         // Date and buttons are invisible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
@@ -447,11 +456,11 @@ public class MainActivityTest {
     @Test
     public void hasCancelOption() {
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(2, R.id.name_text))
+                .atPositionOnView(1, R.id.name_text))
                 .perform(click());
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(2, R.id.reschedule_btn))
+                .atPositionOnView(1, R.id.reschedule_btn))
                 .perform(click());
 
         onView(withText(R.string.cancel)).perform(click());
@@ -461,20 +470,23 @@ public class MainActivityTest {
         Tests whether tasks can be cancelled
     */
     @Test
-    public void canCancelTask() {
+    public void canCancelTask() throws InterruptedException {
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(2, R.id.name_text))
+                .atPositionOnView(1, R.id.name_text))
                 .perform(click());
 
+        Thread.sleep(500);
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(2, R.id.reschedule_btn))
+                .atPositionOnView(1, R.id.reschedule_btn))
                 .perform(click());
 
+        Thread.sleep(500);
         onView(withText(R.string.cancel)).perform(click());
 
+        Thread.sleep(500);
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(2, R.id.name_text))
-                .check(matches(not(withText("Third Todo"))));
+                .atPositionOnView(1, R.id.name_text))
+                .check(matches(not(withText("Second Todo"))));
     }
 
 

--- a/app/src/androidTest/java/com/ad340/whatdo/MainActivityTest.java
+++ b/app/src/androidTest/java/com/ad340/whatdo/MainActivityTest.java
@@ -290,7 +290,7 @@ public class MainActivityTest {
         Tests whether tasks can be expanded from task name or not
      */
     @Test
-    public void tasksExpandAndCollapse() {
+    public void tasksExpandAndCollapse() throws InterruptedException {
         // Date and buttons are invisible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
                 .atPositionOnView(0, R.id.date_text))
@@ -343,9 +343,10 @@ public class MainActivityTest {
                 .atPositionOnView(0, R.id.name_text))
                 .perform(click());
 
+        Thread.sleep(500);
         // Date and buttons are invisible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_text))
+                .atPositionOnView(0, R.id.date_text))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
@@ -373,77 +374,77 @@ public class MainActivityTest {
     public void tasksExpandAndCollapse2() throws InterruptedException {
         // Date and buttons are invisible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_text))
+                .atPositionOnView(1, R.id.date_text))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.notes_btn))
+                .atPositionOnView(1, R.id.notes_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.time_btn))
+                .atPositionOnView(1, R.id.time_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_btn))
+                .atPositionOnView(1, R.id.date_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.reschedule_btn))
+                .atPositionOnView(1, R.id.reschedule_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
-        // Expand fifth task
+        // Expand second task
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.time_text))
+                .atPositionOnView(1, R.id.time_text))
                 .perform(click());
 
         // Date and buttons are visible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_text))
+                .atPositionOnView(1, R.id.date_text))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.reschedule_btn))
+                .atPositionOnView(1, R.id.reschedule_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.notes_btn))
+                .atPositionOnView(1, R.id.notes_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.time_btn))
+                .atPositionOnView(1, R.id.time_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_btn))
+                .atPositionOnView(1, R.id.date_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
-        // Collapse fifth task
+        // Collapse second task
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.time_text))
+                .atPositionOnView(1, R.id.time_text))
                 .perform(click());
 
         Thread.sleep(500);
 
         // Date and buttons are invisible
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_text))
+                .atPositionOnView(1, R.id.date_text))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.reschedule_btn))
+                .atPositionOnView(1, R.id.reschedule_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.notes_btn))
+                .atPositionOnView(1, R.id.notes_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.time_btn))
+                .atPositionOnView(1, R.id.time_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(4, R.id.date_btn))
+                .atPositionOnView(1, R.id.date_btn))
                 .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
     }
 
@@ -536,11 +537,11 @@ public class MainActivityTest {
     @Test
     public void canFinishTask() {
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(2, R.id.todo_item_finished_checkbox))
+                .atPositionOnView(1, R.id.todo_item_finished_checkbox))
                 .perform(click());
 
         onView(withRecyclerView(R.id.todo_list_recycler_view)
-                .atPositionOnView(2, R.id.name_text))
+                .atPositionOnView(1, R.id.name_text))
                 .check(matches(not(withText("Third Todo"))));
     }
 

--- a/app/src/androidTest/java/com/ad340/whatdo/MainActivityTest.java
+++ b/app/src/androidTest/java/com/ad340/whatdo/MainActivityTest.java
@@ -442,8 +442,7 @@ public class MainActivityTest {
 
 
     /*
-    Tests whether tasks have a Cancel option
-
+        Tests whether tasks have a Cancel option
     */
     @Test
     public void hasCancelOption() {
@@ -458,10 +457,29 @@ public class MainActivityTest {
         onView(withText(R.string.cancel)).perform(click());
     }
 
+    /*
+        Tests whether tasks can be cancelled
+    */
+    @Test
+    public void canCancelTask() {
+        onView(withRecyclerView(R.id.todo_list_recycler_view)
+                .atPositionOnView(2, R.id.name_text))
+                .perform(click());
+
+        onView(withRecyclerView(R.id.todo_list_recycler_view)
+                .atPositionOnView(2, R.id.reschedule_btn))
+                .perform(click());
+
+        onView(withText(R.string.cancel)).perform(click());
+
+        onView(withRecyclerView(R.id.todo_list_recycler_view)
+                .atPositionOnView(2, R.id.name_text))
+                .check(matches(not(withText("Third Todo"))));
+    }
+
 
     /*
-    Tests whether tasks have a Reschedule option
-
+        Tests whether tasks have a Reschedule option
     */
     @Test
     public void hasRescheduleOption() {
@@ -474,6 +492,46 @@ public class MainActivityTest {
                 .perform(click());
 
         onView(withText(R.string.reschedule)).perform(click());
+    }
+
+    /*
+        Tests whether tasks can be rescheduled
+    */
+    @Test
+    public void canRescheduleTask() {
+        onView(withRecyclerView(R.id.todo_list_recycler_view)
+                .atPositionOnView(2, R.id.name_text))
+                .perform(click());
+
+        onView(withRecyclerView(R.id.todo_list_recycler_view)
+                .atPositionOnView(2, R.id.reschedule_btn))
+                .perform(click());
+
+        onView(withText(R.string.reschedule)).perform(click());
+
+        int year = 2020;
+        int month = 5;
+        int dayOfMonth = 28;
+        onView(withClassName(Matchers.equalTo(
+                DatePicker.class.getName()))).perform(setDate(year, month, dayOfMonth));
+        onView(withId(android.R.id.button1)).perform(click());
+        onView(withRecyclerView(R.id.todo_list_recycler_view)
+                .atPositionOnView(2, R.id.date_text))
+                .check(matches(withText("Thursday, May 28, 2020")));
+    }
+
+    /*
+        Tests whether tasks can be finished
+    */
+    @Test
+    public void canFinishTask() {
+        onView(withRecyclerView(R.id.todo_list_recycler_view)
+                .atPositionOnView(2, R.id.todo_item_finished_checkbox))
+                .perform(click());
+
+        onView(withRecyclerView(R.id.todo_list_recycler_view)
+                .atPositionOnView(2, R.id.name_text))
+                .check(matches(not(withText("Third Todo"))));
     }
 
     /*

--- a/app/src/androidTest/java/com/ad340/whatdo/MainActivityTest.java
+++ b/app/src/androidTest/java/com/ad340/whatdo/MainActivityTest.java
@@ -16,8 +16,6 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.android.material.appbar.MaterialToolbar;
 
 import org.hamcrest.Matchers;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/app/src/main/java/com/ad340/whatdo/MainActivity.java
+++ b/app/src/main/java/com/ad340/whatdo/MainActivity.java
@@ -47,7 +47,7 @@ public class MainActivity extends AppCompatActivity implements OnTodoInteraction
         toDoRecyclerView.setAdapter(adapter);
         toDoRecyclerView.setLayoutManager(new LinearLayoutManager(this));
 
-        mTodoViewModel.getAllTodos().observe(this, todos -> {
+        mTodoViewModel.getUncompletedTodos().observe(this, todos -> {
             adapter.setTodos(todos);
         });
 
@@ -60,6 +60,8 @@ public class MainActivity extends AppCompatActivity implements OnTodoInteraction
                 showCreateDialog();
             });
 
+
+
         Calendar today = Calendar.getInstance();
         header = findViewById(R.id.top_app_bar);
         StringBuilder displayText = new StringBuilder(header.getTitle());
@@ -71,13 +73,6 @@ public class MainActivity extends AppCompatActivity implements OnTodoInteraction
         header.setTitle(displayText);
     }
 
-//    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-//        super.onActivityResult(requestCode, resultCode, data);
-//
-//        if (requestCode == NEW_TODO_ACTIVITY_REQUEST_CODE && resultCode == RESULT_OK) {
-//            Todo todo = new Todo()
-//        }
-//    }
 
     private void showCreateDialog() {
         final View createView = View.inflate(this, R.layout.create_todo_dialog, null);
@@ -108,7 +103,7 @@ public class MainActivity extends AppCompatActivity implements OnTodoInteraction
                 newTodoEditText.setError("Cannot make an empty task");
             } else {
                 Todo newTodo = new Todo(null, newTodoText, String.valueOf(dateString),
-                        String.valueOf(timeString), null);
+                        String.valueOf(timeString), null, false);
                 mTodoViewModel.insert(newTodo);
                 dialog.dismiss();
             }

--- a/app/src/main/java/com/ad340/whatdo/ToDoItemRecyclerViewAdapter.java
+++ b/app/src/main/java/com/ad340/whatdo/ToDoItemRecyclerViewAdapter.java
@@ -1,5 +1,6 @@
 package com.ad340.whatdo;
 
+import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
@@ -7,12 +8,15 @@ import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CheckBox;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelStoreOwner;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.Calendar;
@@ -29,6 +33,7 @@ public class ToDoItemRecyclerViewAdapter
     private static final String TAG = ToDoItemRecyclerViewAdapter.class.getName();
     private Context context;
     private List<Todo> todos;
+    private TodoViewModel mTodoViewModel;
     private int mExpandedPosition = -1;
     private int previousExpandedPosition = -1;
     private OnTodoInteractionListener listener;
@@ -37,6 +42,8 @@ public class ToDoItemRecyclerViewAdapter
     ToDoItemRecyclerViewAdapter(Context context) {
         this.context = context;
         listener = (OnTodoInteractionListener) this.context;
+        mTodoViewModel = new ViewModelProvider((ViewModelStoreOwner) context)
+                .get(TodoViewModel.class);
     }
 
     @NonNull
@@ -66,6 +73,13 @@ public class ToDoItemRecyclerViewAdapter
             holder.toDoTaskName.setText(todo.getTitle());
             holder.toDoDate.setText(todo.getDate());
             holder.toDoTime.setText(todo.getTime());
+
+            holder.toDoFinishedCheckbox.setChecked(false);
+            holder.toDoFinishedCheckbox.setOnClickListener(view -> {
+                mTodoViewModel.updateTodo(todo, "", 5);
+                notifyDataSetChanged();
+            });
+
             holder.rescheduleButton.setOnClickListener(view -> {
                 //make popup menu
                 PopupMenu popup = new PopupMenu(context, holder.rescheduleButton);
@@ -78,7 +92,10 @@ public class ToDoItemRecyclerViewAdapter
                             //handle reschedule click
                             break;
                         case R.id.cancel:
-                            //handle cancel click
+                            mTodoViewModel.removeTodo(todo);
+                            mExpandedPosition = isExpanded ? -1:position;
+                            notifyItemChanged(previousExpandedPosition);
+                            notifyItemChanged(position);
                             break;
                     }
                     return false;
@@ -132,6 +149,7 @@ public class ToDoItemRecyclerViewAdapter
         ImageButton rescheduleButton;
         ImageButton toDoDateButton;
         ImageButton toDoTimeButton;
+        CheckBox toDoFinishedCheckbox;
 
         ToDoItemViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -139,6 +157,7 @@ public class ToDoItemRecyclerViewAdapter
             toDoTime = itemView.findViewById(R.id.time_text);
             toDoDate = itemView.findViewById(R.id.date_text);
             todoDetail = itemView.findViewById(R.id.todo_detail);
+            toDoFinishedCheckbox = itemView.findViewById(R.id.todo_item_finished_checkbox);
             rescheduleButton = itemView.findViewById(R.id.reschedule_btn);
             toDoDateButton = itemView.findViewById(R.id.date_btn);
             toDoTimeButton = itemView.findViewById(R.id.time_btn);

--- a/app/src/main/java/com/ad340/whatdo/ToDoItemRecyclerViewAdapter.java
+++ b/app/src/main/java/com/ad340/whatdo/ToDoItemRecyclerViewAdapter.java
@@ -89,7 +89,10 @@ public class ToDoItemRecyclerViewAdapter
                 popup.setOnMenuItemClickListener(item -> {
                     switch (item.getItemId()) {
                         case R.id.reschedule:
-                            //handle reschedule click
+                            new DatePickerDialog(context, date,
+                                    c.get(Calendar.YEAR),
+                                    c.get(Calendar.MONTH),
+                                    c.get(Calendar.DAY_OF_MONTH)).show();
                             break;
                         case R.id.cancel:
                             mTodoViewModel.removeTodo(todo);

--- a/app/src/main/java/com/ad340/whatdo/Todo.java
+++ b/app/src/main/java/com/ad340/whatdo/Todo.java
@@ -27,7 +27,6 @@ public class Todo {
     private String time;
     public String getTime() { return this.time; }
 
-    @Ignore
     @ColumnInfo(name = "isCompleted")
     private boolean isCompleted;
     public boolean getCompleted() { return this.isCompleted; }
@@ -36,13 +35,13 @@ public class Todo {
     private String notes;
     public String getNotes() { return this.notes; }
 
-    public Todo(Integer id, @NonNull String title, String date, String time, String notes) {
+    public Todo(Integer id, @NonNull String title, String date, String time, String notes, Boolean isCompleted) {
         this.id = id;
         this.title = title;
         this.date = date;
         this.time = time;
         this.notes = notes;
-        this.isCompleted = false;
+        this.isCompleted = isCompleted;
     }
 
 //    @Ignore

--- a/app/src/main/java/com/ad340/whatdo/TodoDao.java
+++ b/app/src/main/java/com/ad340/whatdo/TodoDao.java
@@ -17,8 +17,14 @@ public interface TodoDao {
     @Query("SELECT * from todo_table ORDER BY title ASC")
     LiveData<List<Todo>> getAllTodos();
 
+    @Query("SELECT * FROM todo_table WHERE NOT isCompleted")
+    LiveData<List<Todo>> getUncompletedTodos();
+
     @Query("DELETE FROM todo_table")
     void deleteAll();
+
+    @Query("DELETE FROM todo_table WHERE id = :id")
+    void cancelTodo(int id);
 
     @Query("UPDATE todo_table SET title = :title WHERE id = :id")
     void updateTodoTitle(int id, String title);
@@ -31,4 +37,7 @@ public interface TodoDao {
 
     @Query("UPDATE todo_table SET notes = :notes WHERE id = :id")
     void updateTodoNotes(int id, String notes);
+
+    @Query("UPDATE todo_table SET isCompleted = 1 WHERE id = :id")
+    void setTodoCompleted(int id);
 }

--- a/app/src/main/java/com/ad340/whatdo/TodoRepository.java
+++ b/app/src/main/java/com/ad340/whatdo/TodoRepository.java
@@ -10,14 +10,18 @@ public class TodoRepository {
 
     private TodoDao todoDao;
     private LiveData<List<Todo>> allTodos;
+    private LiveData<List<Todo>> uncompletedTodos;
 
     TodoRepository(Application application) {
         TodoRoomDatabase db = TodoRoomDatabase.getDatabase(application);
         todoDao = db.todoDao();
         allTodos = todoDao.getAllTodos();
+        uncompletedTodos = todoDao.getUncompletedTodos();
     }
 
     LiveData<List<Todo>> getAllTodos() { return allTodos; }
+
+    LiveData<List<Todo>> getUncompletedTodos() { return uncompletedTodos; }
 
     void updateTodo(Todo todo, String data, int type) {
         int id = todo.getId();
@@ -34,6 +38,9 @@ public class TodoRepository {
             case 4: // update notes
                 TodoRoomDatabase.databaseWriteExecutor.execute(() -> todoDao.updateTodoNotes(id, data));
                 break;
+            case 5: // set to completed
+                TodoRoomDatabase.databaseWriteExecutor.execute(() -> todoDao.setTodoCompleted(id));
+                break;
             default: // type not recognized
                 StringBuilder errMessage  = new StringBuilder("Data type of ")
                         .append(type).append(" not recognized.");
@@ -44,5 +51,10 @@ public class TodoRepository {
 
     void insert(Todo todo) {
         TodoRoomDatabase.databaseWriteExecutor.execute(() -> { todoDao.insert(todo);});
+    }
+
+    void removeTodo(Todo todo) {
+        int id = todo.getId();
+        TodoRoomDatabase.databaseWriteExecutor.execute(() -> { todoDao.cancelTodo(id);});
     }
 }

--- a/app/src/main/java/com/ad340/whatdo/TodoRoomDatabase.java
+++ b/app/src/main/java/com/ad340/whatdo/TodoRoomDatabase.java
@@ -21,6 +21,7 @@ public abstract class TodoRoomDatabase extends RoomDatabase {
     static final ExecutorService databaseWriteExecutor =
             Executors.newFixedThreadPool(NUMBER_OF_THREADS);
 
+    
     static TodoRoomDatabase getDatabase(final Context context) {
         if (INSTANCE == null) {
             synchronized (TodoRoomDatabase.class) {

--- a/app/src/main/java/com/ad340/whatdo/TodoRoomDatabase.java
+++ b/app/src/main/java/com/ad340/whatdo/TodoRoomDatabase.java
@@ -44,16 +44,19 @@ public abstract class TodoRoomDatabase extends RoomDatabase {
             databaseWriteExecutor.execute(() -> {
                 TodoDao dao = INSTANCE.todoDao();
                 dao.deleteAll();
-                Todo todo = new Todo(null, "First Todo", null, null, null);
+                Todo todo = new Todo(null, "First Todo", null, null, null, false);
                 dao.insert(todo);
-                todo = new Todo(null, "Second Todo", null, null, null);
+                todo = new Todo(null, "Second Todo", null, null, null, false);
                 dao.insert(todo);
-                todo = new Todo(null, "Third Todo", null, null, null);
+                todo = new Todo(null, "Third Todo", null, null, null, false);
                 dao.insert(todo);
-                todo = new Todo(null, "Fourth Todo", null, null, null);
+                todo = new Todo(null, "Fourth Todo", null, null, null, false);
                 dao.insert(todo);
-                todo = new Todo(null, "Fifth Todo", null, null, null);
+                todo = new Todo(null, "Fifth Todo", null, null, null, false);
                 dao.insert(todo);
+                todo = new Todo(null, "Finished Todo", null, null, null, true);
+                dao.insert(todo);
+
             });
 
 

--- a/app/src/main/java/com/ad340/whatdo/TodoViewModel.java
+++ b/app/src/main/java/com/ad340/whatdo/TodoViewModel.java
@@ -12,16 +12,22 @@ public class TodoViewModel extends AndroidViewModel {
 
     private TodoRepository repository;
     private LiveData<List<Todo>> allTodos;
+    private LiveData<List<Todo>> uncompletedTodos;
 
     public TodoViewModel(Application application) {
         super(application);
         repository = new TodoRepository(application);
         allTodos = repository.getAllTodos();
+        uncompletedTodos = repository.getUncompletedTodos();
     }
 
     LiveData<List<Todo>> getAllTodos() { return allTodos; }
 
+    LiveData<List<Todo>> getUncompletedTodos() { return uncompletedTodos; }
+
     public void insert(Todo todo) { repository.insert(todo);}
 
     public void updateTodo(Todo todo, String data, int type) { repository.updateTodo(todo, data, type); }
+
+    public void removeTodo(Todo todo) { repository.removeTodo(todo); }
 }

--- a/app/src/test/java/com/ad340/whatdo/MainActivityUnitTests.java
+++ b/app/src/test/java/com/ad340/whatdo/MainActivityUnitTests.java
@@ -8,7 +8,7 @@ public class MainActivityUnitTests {
 
     @Test
     public void get_completedWorks() {
-        Todo todo = new Todo(null, "Test todo", null, null, null);
+        Todo todo = new Todo(null, "Test todo", null, null, null, false);
         assertFalse(todo.getCompleted());
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'org.jacoco:org.jacoco.core:0.7.9'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 09 15:20:38 PDT 2020
+#Mon Jun 01 15:11:15 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -49,13 +49,13 @@ task jacocoTestReport(type : JacocoReport, dependsOn : ['testDebugUnitTest']) {
         html.enabled = true
     }
 
-    classDirectories = files([javaClasses, kotlinClasses])
+    getClassDirectories().setFrom(files([javaClasses, kotlinClasses]))
 
-    sourceDirectories = files(coverageSourceDirs)
-    executionData     = fileTree(
+    getSourceDirectories().setFrom(files(coverageSourceDirs))
+    getExecutionData().setFrom(fileTree(
             dir     : "$buildDir",
             include : [ 'jacoco/testDebugUnitTest.exec', 'outputs/code_coverage/debugAndroidTest/connected/*coverage.ec' ]
-    )
+    ))
 
     doFirst {
         files([javaClasses, kotlinClasses]).getFiles().each { file ->
@@ -75,13 +75,13 @@ task jacocoTestReportLocal(type : JacocoReport, dependsOn : ['testDebugUnitTest'
         html.enabled = true
     }
 
-    classDirectories = files([javaClasses, kotlinClasses])
+    getClassDirectories().setFrom(files([javaClasses, kotlinClasses]))
 
-    sourceDirectories = files(coverageSourceDirs)
-    executionData     = fileTree(
+    getSourceDirectories().setFrom(files(coverageSourceDirs))
+    getExecutionData().setFrom(fileTree(
             dir     : "$buildDir",
             include : [ 'jacoco/testDebugUnitTest.exec', 'outputs/code_coverage/debugAndroidTest/connected/*coverage.ec' ]
-    )
+    ))
 
     doFirst {
         files([javaClasses, kotlinClasses]).getFiles().each { file ->


### PR DESCRIPTION
## Description of Issue
*What prompted this code change? Link any relevant issues*
These changes are to fulfill issue #27, handling finish todo clicks, cancel todo clicks, and reschedule todo clicks.

## Testing
*Have you tested this change? On what devices*
With Android Studio VM (Pixel 3a - Android 29)
* Clicking the checkbox next to a to do removes it from the list and sets finished to true in the database
* Clicking the cancel button in the 3 dots of the extended todo menu removes the todo from the list and also deletes it from the database
* Clicking the cancel button in the 3 dots of the extended todo menu opens a date picker and works much the same as the regular date picker.
* All tests pass correctly


## Time Spent
*How long did you estimate this task would take?*
2 hour

*How long did it take you to work on this issue?*
So many hours. I have no idea how many. Mainly composed of trying and failing to get testing to work. Still haven't figured out why it doesn't work on my machine. 

## Checklist
- [x] Did you squash your commits for this issue?
- [x] Did you clear your linter errors?
- [x] Did you remove all console logs?
